### PR TITLE
Update setup.md by removing broken script ref.

### DIFF
--- a/docs/run/ci/setup.md
+++ b/docs/run/ci/setup.md
@@ -35,9 +35,5 @@ most CI platforms provide a way to specify secrets in your environment variables
 Last, you'll need to execute the Insights CI script within your CI pipeline.
 You may want to download, inspect, and store a copy of the script in your repository.
 The in-app instructions will also provide a SHA which can be checked to verify the integrity of the script.
-```
-curl https://insights.fairwinds.com/static/insights-ci.sh
-```
 
 Your repository will show up in the Insights UI once that script has been successfully run.
-


### PR DESCRIPTION
Link ref. is broken and should be removed
💡 Is there a permanent link that always points to the latest version of the script? I think that would be a better approach.