### PR TITLE
Update publish docs to use secrets from vault

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,8 @@
+version: 2.1
+
+orbs:
+  rok8s: fairwinds/rok8s-scripts@11
+
 references:
   test_and_build: &test_and_build
     name: Build Docs Site
@@ -7,7 +12,6 @@ references:
       npm install
       npm run check-links
       npm run build
-
 
 jobs:
   test:
@@ -22,13 +26,39 @@ jobs:
       - image: cimg/node:15.5.1
     steps:
       - checkout
-      - run: *test_and_build
       - run:
-          name: Install AWS CLI
+          name: Build Docs Site
           command: |
+            set -e
+            cd ./docs
+            npm install
+            npm run check-links
+            npm run build
+      - run:
+          name: Install Tools
+          command: |
+            cd /tmp
+            echo "Installing AWS CLI"
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
             unzip awscliv2.zip
             sudo ./aws/install
+
+            echo "Installing Hashicorp Vault"
+            curl -LO https://releases.hashicorp.com/vault/1.9.3/vault_1.9.3_linux_amd64.zip
+            unzip vault_1.9.3_linux_amd64.zip
+            sudo mv vault /usr/bin/vault
+            sudo chmod +x /usr/bin/vault
+            vault --version
+
+            echo "Installing yq"
+            curl -LO https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64
+.tar.gz
+            tar -zxvf yq_linux_amd64.tar.gz
+            sudo mv yq_linux_amd64 /usr/bin/yq
+            sudo chmod +x /usr/bin/yq
+            yq --version
+      - rok8s/get_vault_env:
+          vault_path: repo/insights-docs/env
       - run:
           name: Publish Docs Site to S3
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,7 @@ jobs:
             vault --version
 
             echo "Installing yq"
-            curl -LO https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64
-.tar.gz
+            curl -LO https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64.tar.gz
             tar -zxvf yq_linux_amd64.tar.gz
             sudo mv yq_linux_amd64 /usr/bin/yq
             sudo chmod +x /usr/bin/yq


### PR DESCRIPTION
TODO:
- [x] Get vault token injection enabled


## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Get secrets from vault instead of circleci

### What changes did you make?
Updated circleci config