### PR TITLE
FWI-1726 - Update Insights Docs for insights-cli 1.0 and OPA V2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,3 +38,25 @@ features like [Slack notifications](/installation/integrations/slack),
 and our [supported plugins](/technical-details/reports/polaris).
 
 <!-- Begin boilerplate -->
+## Join the Fairwinds Open Source Community
+
+The goal of the Fairwinds Community is to exchange ideas, influence the open source roadmap,
+and network with fellow Kubernetes users.
+[Chat with us on Slack](https://join.slack.com/t/fairwindscommunity/shared_invite/zt-e3c6vj4l-3lIH6dvKqzWII5fSSFDi1g)
+or
+[join the user group](https://www.fairwinds.com/open-source-software-user-group) to get involved!
+
+<a href="https://www.fairwinds.com/t-shirt-offer?utm_source=insights-docs&utm_medium=insights-docs&utm_campaign=insights-docs-tshirt">
+  <img src="https://www.fairwinds.com/hubfs/Doc_Banners/Fairwinds_OSS_User_Group_740x125_v6.png" alt="Love Fairwinds Open Source? Share your business email and job title and we'll send you a free Fairwinds t-shirt!" />
+</a>
+
+## Other Projects from Fairwinds
+
+Enjoying insights-docs? Check out some of our other projects:
+* [Polaris](https://github.com/FairwindsOps/Polaris) - Audit, enforce, and build policies for Kubernetes resources, including over 20 built-in checks for best practices
+* [Goldilocks](https://github.com/FairwindsOps/Goldilocks) - Right-size your Kubernetes Deployments by compare your memory and CPU settings against actual usage
+* [Pluto](https://github.com/FairwindsOps/Pluto) - Detect Kubernetes resources that have been deprecated or removed in future versions
+* [Nova](https://github.com/FairwindsOps/Nova) - Check to see if any of your Helm charts have updates available
+* [rbac-manager](https://github.com/FairwindsOps/rbac-manager) - Simplify the management of RBAC in your Kubernetes clusters
+
+Or [check out the full list](https://www.fairwinds.com/open-source-software?utm_source=insights-docs&utm_medium=insights-docs&utm_campaign=insights-docs)

--- a/docs/configure/automation/rules.md
+++ b/docs/configure/automation/rules.md
@@ -29,6 +29,7 @@ if (ActionItem.ResourceLabels['app'] === 'polaris') {
 }
 ```
 
+### Automation Rule Input
 The main input is `ActionItem`, which contains
 information about the issue detected. The following fields are available:
 * `Cluster`
@@ -45,6 +46,7 @@ information about the issue detected. The following fields are available:
 
 **Please see the [Supported Checks](https://insights.docs.fairwinds.com/reports/supported-checks/) page for a list of available `EventType` and `ReportType` options.**
 
+### Editable Fields
 The following fields can be edited:
 * `Severity`
 * `Resolution` - can be set to the constants `WILL_NOT_FIX_RESOLUTION` or `WORKING_AS_INTENDED_RESOLUTION`
@@ -68,5 +70,4 @@ You can use the Automation tab to add new rules, edit rules, and enable/disable 
 
 ### CLI
 To manage rules in an infrastructure-as-code repository, you can use the [Insights CLI](/configure/cli/automation-rules).
-Be sure to read the [CLI documentation](/configure/cli/cli) before getting started here.
-
+Be sure to read the [CLI documentation](/configure/cli/cli) before getting started.

--- a/docs/configure/cli/automation-rules.md
+++ b/docs/configure/cli/automation-rules.md
@@ -1,37 +1,96 @@
-# Uploading Rules
-### CLI
-To manage rules in an infrastructure-as-code repository, you can use the [Insights CLI](/configure/cli/cli).
-Be sure to read the [CLI documentation](/configure/cli/cli) before getting started here.
+# Interacting With Automation Rules Via the CLI
 
-First, create a new YAML file in the `rules` directory. This will contain your
-JavaScript, as well as some metadata.
+You can use the Insights Command-line Interface (CLI) To manage automation rules.
+Be sure to first read the [general CLI documentation](/configure/cli/cli) which covers instllation and prerequisites.
+
+## Pushing Automation Rules to Insights
+The Insights CLI push commands expect a directory structure like the following when pushing automation rules:
+
+```
+.
++-- rules
+|   +-- rule1.yaml
+|   +-- another-rule.yaml
+```
+
+* Note that the base file name (minus the .yaml extension) is arbitrary.
+
+### Example
+To upload an automation rule to Insights, create the file `api-action-items.yaml` in the `rules` sub-directory. This will contain the
+rule JavaScript and accompanying metadata.
+
 ```yaml
 name: "Assign API Action Items"
-description: "Assigns all Action Items in the api namespace to api-team@"
+description: "Assigns all Action Items in the api namespace to api-team@acme-co.com"
 action: |
   if (ActionItem.ResourceNamespace === 'api') {
     ActionItem.AssigneeEmail = 'api-team@acme-co.com';
   }
 ```
 
-Then run:
+Next use the Insights CLI to push this automation rule to Insights
+
 ```bash
-FAIRWINDS_TOKEN=$YOUR_TOKEN insights policy sync --rules --organization $YOUR_ORG
+FAIRWINDS_TOKEN=YOUR_TOKEN insights-cli push rules --organization YOUR_ORG_NAME
 ```
 
-While the rule won't be applied retroactively, the next time the agent,
-CI process, or Admission Controller runs, the rule will be triggered.
+* This pushes automation rules from the current directory, expecting it to contain the `rules` sub-directory.
+* Typically the `FAIRWINDS_TOKEN` environment variable is set elsewhere and is not included each time the CLI is run.
+* The Insights organization can also be specified in a configuration file, described in the [general Insights CLI documentation](/configure/cli/cli).
+* Use the `--push-directory` option to specify an alternative base directory.
+* It is also possible to override the name of the `rules` sub-directory - see `insights-cli push rules --help` for details.
 
-If you want to be sure the rule worked, you can manually trigger the agent by running:
-```
-kubectl -n insights-agent create job rule-test --from cronjob/$REPORT
-```
-where $REPORT is `polaris`, `trivy`, or any other report type you'd like to test.
+#### Automation Rule Metadata Fields
+The following metadata fields can be specified in the rule file:
 
-#### Metadata Fields
 * `name`
 * `description`
 * `context` - one of `Agent`, `CI/CD`, or `AdmissionController` (or leave blank for all three)
 * `cluster` - the name of a specific cluster this rule should apply to
 * `repository` - the name of a specific repo this rule should apply to
 * `reporttype` - the type of report (e.g. `polaris` or `trivy`) this rule should apply to
+
+### Verifying Success
+To see a list of automation rules in your Insights organization, you can run:
+
+```bash
+FAIRWINDS_TOKEN=YOUR_TOKEN insights-cli list rules --organization YOUR_ORG_NAME
+```
+
+
+The next time the Insights agent,
+CI process, or Admission Controller runs, the rule will be triggered. The rule won't be applied retroactively.
+
+To be sure the rule functions immediately, you can manually trigger the agent by running:
+
+```bash
+kubectl -n insights-agent create job rule-test --from cronjob/$REPORT
+```
+
+* Where $REPORT is `polaris`, `trivy`, or any other report type you'd like to test.
+
+#### Automation Rule Metadata Fields
+The following metadata fields can be specified in the rule file:
+
+* `name`
+* `description`
+* `context` - one of `Agent`, `CI/CD`, or `AdmissionController` (or leave blank for all three)
+* `cluster` - the name of a specific cluster this rule should apply to
+* `repository` - the name of a specific repo this rule should apply to
+* `reporttype` - the type of report (e.g. `polaris` or `trivy`) this rule should apply to
+
+### Deleting From Insights
+By default, the Insights CLI will not _delete_ any automation rules from Insights - it will
+only add or update them.
+This means there might be some automation rules running in Insights that are not
+tracked in your IaC repository.
+
+You can add the `--delete` flag to the `push rules` command, which
+will delete any automation rules from Insights that **do not exist** in your IaC repository. Adding the `--dry-run` flag will explain which rules would be deleted without making changes to Insights.
+
+## Pushing Automation Rules Along With OPA Policies
+Both automation rules and OPA policies can be pushed to Insights using the single command `insights-cli push all`.
+
+* Note that the `--delete` flag is not available for the `push all` command, to avoid unexpected deletes of insights-cli managed configuration resources that are added in the future.
+
+For additional information about OPA policies, see the [CLI OPA documentation](configure/cli/opa).

--- a/docs/configure/cli/automation-rules.md
+++ b/docs/configure/cli/automation-rules.md
@@ -15,7 +15,7 @@ The Insights CLI push commands expect a directory structure like the following w
 
 * Note that the base file name (minus the .yaml extension) is arbitrary.
 
-### Example
+### Pushing Automation Rules Example
 To upload an automation rule to Insights, create the file `api-action-items.yaml` in the `rules` sub-directory. This will contain the
 rule JavaScript and accompanying metadata.
 
@@ -69,17 +69,7 @@ kubectl -n insights-agent create job rule-test --from cronjob/$REPORT
 
 * Where $REPORT is `polaris`, `trivy`, or any other report type you'd like to test.
 
-#### Automation Rule Metadata Fields
-The following metadata fields can be specified in the rule file:
-
-* `name`
-* `description`
-* `context` - one of `Agent`, `CI/CD`, or `AdmissionController` (or leave blank for all three)
-* `cluster` - the name of a specific cluster this rule should apply to
-* `repository` - the name of a specific repo this rule should apply to
-* `reporttype` - the type of report (e.g. `polaris` or `trivy`) this rule should apply to
-
-### Deleting From Insights
+### Deleting Automation Rules From Insights
 By default, the Insights CLI will not _delete_ any automation rules from Insights - it will
 only add or update them.
 This means there might be some automation rules running in Insights that are not
@@ -93,4 +83,4 @@ Both automation rules and OPA policies can be pushed to Insights using the singl
 
 * Note that the `--delete` flag is not available for the `push all` command, to avoid unexpected deletes of insights-cli managed configuration resources that are added in the future.
 
-For additional information about OPA policies, see the [CLI OPA documentation](configure/cli/opa).
+For additional information about OPA policies, see the [CLI OPA documentation](/configure/cli/opa).

--- a/docs/configure/cli/cli.md
+++ b/docs/configure/cli/cli.md
@@ -1,7 +1,7 @@
 ---
 meta:
   - name: description
-    content: "Fairwinds Insights | Documentation. The Fairwinds Insights CLI is a command-line tool for interacting with the API. Push OPA policies and automation rules to Insights, and test/validate OPA policies offline."
+    content: "Fairwinds Insights | Documentation. The Fairwinds Insights CLI is a command-line tool for interacting with the API. It can be used to push OPA policies and automation rules to Insights, and test/validate OPA policies offline."
 ---
 # CLI Utility
 
@@ -45,96 +45,8 @@ options:
 By default, the CLI will look for this file at `./fairwinds-insights.yaml`, but its
 location can be configured by passing in the `--config <filename>` flag.
 
-## Pushing OPA Policies and Automation Rules to Insights
-### Directory Structure
-The Insights CLI expects to find two directories (either in the current working directory,
-or in the directory specified in the `--push-directory` flag):
+## Working With OPA Policies and Automation Rules
 
-* `./opa/` - a directory containing any OPA policies, each within its own sub-directory
-* `./rules/` - a directory containing any automation rules
-
-An example directory structure might look like this:
-```
-.
-+-- opa
-|   +-- policy1
-|       +-- policy.rego
-|       +-- instance1.yaml
-|   +-- policy2
-|       +-- policy.rego
-|       +-- instance1.yaml
-|       +-- instance2.yaml
-+-- rules
-|   +-- rule1.yaml
-|   +-- rule2.yaml
-```
-
-* The `instance*.yaml` files are only required for Insights version 1 OPA policies. See the [OPA Policy docs](/configure/cli/opa) for details.
-* It is possible to override the `opa` and `rules` sub-directory names using additional flags - see `insights-cli push all --help` for details.
-
-To learn more about the OPA policy and automation rule file formats, see the
-[OPA Policy docs](/configure/cli/opa) and the
-[Automation Rule docs](/configure/cli/automation-rules)
-
-### Push Commands
-To push OPA policies and automation rules from your infrastructure-as-code repo to Insights, use one of the `insights-cli push` commands.
-
-* `push all` - Push OPA policies and automation rules.
-* `push opa` - Push only OPA policies.
-* `push rules` - Push  only automation rules.
-
-```bash
-insights-cli push all --push-directory /path/to/iac/
-```
-
-#### Deleting From Insights
-By default, insights-cli will not _delete_ any OPA policies or automation rules from Insights - it will
-only add or update resources.
-This means there might be some OPA policies or rules running in Insights that are not
-tracked in your IaC repository.
-
-You can add the `--delete` flag to the `push opa` or `push rules` commands, which
-will delete any corresponding resources from Insights that **do not exist** in your IaC repository. Adding the `--dry-run` flag will explain which resources would be deleted without making changes to Insights.
-
-* Note that the `--delete` flag is not available for the `push all` command, to avoid unexpected deletes of insights-cli managed configuration resources that are added in the future.
-
-```bash
-insights-cli push opa --push-directory /path/to/iac/ --delete --dry-run
-insights-cli push rules --push-directory /path/to/iac/ --delete --dry-run
-```
-
-## Validate and Debug OPA Policies
-The Insights CLI can validate Insights OPA policies, which is useful for local policy development or or in your CI/CD workflow. Validation includes
-
-* Rego syntax - the query language used by OPA policies.
-* Some input validation for Insights-provided rego functions, such as `kubernetes()` and `insightsinfo()`.
-* Any policy output contains a valid Insights action item.
-
-The `insights-cli validate opa` command requires an OPA policy file, and a Kubernetes manifest file that will be passed as input to the policy.
-
-```bash
-insights-cli validate opa --rego-file not-in-namespace/policy.rego --kube-object-file test-pod.yaml
-```
-
-Other command-line options are available to override metadata to ease testing policies, such as
-
-* The Kubernetes namespace that may b specified in the manifest file, to help test policies that vary behavior per namespace.
-* Information returned by Insights-provided rego functions like `insightsinfo()`.
-
-See `insights-cli validate opa --help` and the [OPA Policy docs](/configure/cli/opa) for details.
-
-### Debug Print Statements
-Rego `print()` statements will be included in the output of `insights-cli validate opa`, to help debug policy execution. For example, this incomplete policy prints two debug messages.
-
-```rego
-package fairwinds
-
-incompleteRule[actionItem] {
-  print("starting our rule")
-  input.kind == "Deployment"
-  print("made it past the kind detection, which is ", input.kind)
-  actionItem := {
-    # This is incomplete!
-  }
-}
-```
+To learn more about using the CLI to work with OPA policies and automation rules, see the
+[CLI OPA Policy docs](/configure/cli/opa) and the
+[CLI Automation Rule docs](/configure/cli/automation-rules).

--- a/docs/configure/cli/cli.md
+++ b/docs/configure/cli/cli.md
@@ -1,14 +1,14 @@
 ---
 meta:
   - name: description
-    content: "Fairwinds Insights | Documentation. The Fairwinds Insights CLI is a command-line tool for interacting with the API. Keep policies synced to Git repository."
+    content: "Fairwinds Insights | Documentation. The Fairwinds Insights CLI is a command-line tool for interacting with the API. Push OPA policies and automation rules to Insights, and test/validate OPA policies offline."
 ---
 # CLI Utility
 
 The [Fairwinds Insights CLI](https://github.com/FairwindsOps/insights-cli)
 is a command-line tool for interacting with
 the Fairwinds Insights API. In particular, it makes it easy to manage
-policy-as-code, keeping your Insights policies synced to a Git repository.
+Insights OPA policies and automation rules as code, and test/validate OPA policies offline.
 
 ## Installation
 ### Homebrew Tap
@@ -17,13 +17,14 @@ brew install FairwindsOps/tap/insights
 ```
 
 ### Binary
-Install the binary from our [releases](https://github.com/FairwindsOps/insights-cli/releases) page.
+Install the binary from our [releases](https://github.com/FairwindsOps/insights-cli/releases?q=draft%3Afalse+prerelease%3Afalse&expanded=true) page.
 
-## Usage
+## Preparation
 To start using the Insights CLI, you'll need to retrieve your admin token
 from your organization's settings page at insights.fairwinds.com/orgs
 
 Set that token in your environment with
+
 ```bash
 export FAIRWINDS_TOKEN=$YOUR_ADMIN_TOKEN
 ```
@@ -38,23 +39,24 @@ organization name and hostname (for self-hosted deployments)
 ```yaml
 options:
   organization: acme-co
-  hostname: https://example.com
+  hostname: https://insights.example.com
 ```
 
 By default, the CLI will look for this file at `./fairwinds-insights.yaml`, but its
 location can be configured by passing in the `--config <filename>` flag.
 
-## Directory Structure
-
+## Pushing OPA Policies and Automation Rules to Insights
+### Directory Structure
 The Insights CLI expects to find two directories (either in the current working directory,
-or in the directory specified in the `--directory` flag):
-* `./checks/` - a directory containing any OPA policies
-* `./rules/` - a diretory containing any automation rules
+or in the directory specified in the `--push-directory` flag):
+
+* `./opa/` - a directory containing any OPA policies, each within its own sub-directory
+* `./rules/` - a directory containing any automation rules
 
 An example directory structure might look like this:
 ```
 .
-+-- checks
++-- opa
 |   +-- policy1
 |       +-- policy.rego
 |       +-- instance1.yaml
@@ -67,22 +69,72 @@ An example directory structure might look like this:
 |   +-- rule2.yaml
 ```
 
-To learn more about the individual file formats, see the
+* The `instance*.yaml` files are only required for Insights version 1 OPA policies. See the [OPA Policy docs](/configure/cli/opa) for details.
+* It is possible to override the `opa` and `rules` sub-directory names using additional flags - see `insights-cli push all --help` for details.
+
+To learn more about the OPA policy and automation rule file formats, see the
 [OPA Policy docs](/configure/cli/opa) and the
 [Automation Rule docs](/configure/cli/automation-rules)
 
-## Syncing
-To sync your infrastructure-as-code repo to Insights, you can run
+### Push Commands
+To push OPA policies and automation rules from your infrastructure-as-code repo to Insights, use one of the `insights-cli push` commands.
+
+* `push all` - Push OPA policies and automation rules.
+* `push opa` - Push only OPA policies.
+* `push rules` - Push  only automation rules.
 
 ```bash
-insights policy sync --directory /path/to/iac/
+insights-cli push all --push-directory /path/to/iac/
 ```
 
-### Full Sync
-By default, Insights will not _delete_ any remote rules/checks - it will
-only upload new rules/checks, or update existing rules/checks.
-This means there might be some rules/checks that are running in Insights, but not
+#### Deleting From Insights
+By default, insights-cli will not _delete_ any OPA policies or automation rules from Insights - it will
+only add or update resources.
+This means there might be some OPA policies or rules running in Insights that are not
 tracked in your IaC repository.
 
-If you'd like to ensure a perfect sync, you can add the `--fullsync` flag, which
-will delete any remote rules that do not exist in your IaC repository.
+You can add the `--delete` flag to the `push opa` or `push rules` commands, which
+will delete any corresponding resources from Insights that **do not exist** in your IaC repository. Adding the `--dry-run` flag will explain which resources would be deleted without making changes to Insights.
+
+* Note that the `--delete` flag is not available for the `push all` command, to avoid unexpected deletes of insights-cli managed configuration resources that are added in the future.
+
+```bash
+insights-cli push opa --push-directory /path/to/iac/ --delete --dry-run
+insights-cli push rules --push-directory /path/to/iac/ --delete --dry-run
+```
+
+## Validate and Debug OPA Policies
+The Insights CLI can validate Insights OPA policies, which is useful for local policy development or or in your CI/CD workflow. Validation includes
+
+* Rego syntax - the query language used by OPA policies.
+* Some input validation for Insights-provided rego functions, such as `kubernetes()` and `insightsinfo()`.
+* Any policy output contains a valid Insights action item.
+
+The `insights-cli validate opa` command requires an OPA policy file, and a Kubernetes manifest file that will be passed as input to the policy.
+
+```bash
+insights-cli validate opa --rego-file not-in-namespace/policy.rego --kube-object-file test-pod.yaml
+```
+
+Other command-line options are available to override metadata to ease testing policies, such as
+
+* The Kubernetes namespace that may b specified in the manifest file, to help test policies that vary behavior per namespace.
+* Information returned by Insights-provided rego functions like `insightsinfo()`.
+
+See `insights-cli validate opa --help` and the [OPA Policy docs](/configure/cli/opa) for details.
+
+### Debug Print Statements
+Rego `print()` statements will be included in the output of `insights-cli validate opa`, to help debug policy execution. For example, this incomplete policy prints two debug messages.
+
+```rego
+package fairwinds
+
+incompleteRule[actionItem] {
+  print("starting our rule")
+  input.kind == "Deployment"
+  print("made it past the kind detection, which is ", input.kind)
+  actionItem := {
+    # This is incomplete!
+  }
+}
+```

--- a/docs/configure/cli/opa.md
+++ b/docs/configure/cli/opa.md
@@ -1,14 +1,84 @@
-# Uploading Policies
+# Interacting With OPA Policies Via the CLI
+You can use the Insights Command-line Interface (CLI) To manage OPA policies, and test/validate OPA policies offline.
+Be sure to first read the [general CLI documentation](/configure/cli/cli) which covers instllation and prerequisites.
 
-### Via the CLI
-To manage policies in an infrastructure-as-code repository, you can use the [Insights CLI](/configure/cli/cli).
-Be sure to read the [CLI documentation](/configure/cli/cli) before getting started here.
+## V1 and V2 Insights OPA Policies
+Version 2 of the [Insights Agent](/configuration/agent/install-hub) supports a new `V2` version of Insights OPA policies which no longer uses an accompanying yaml file to define the Kubernetes Kinds that the policy will process. We recommend use of V2 policies moving forward. See the [[OPA report documentation](/configure/policy/policy) for more information about how V1 and V2 OPA policies differ.
 
-#### Syncing Policies
-The sync functionality expects a directory structure like the following:
+## Pushing V2 OPA Policies to Insights
+The Insights CLI push commands expect a directory structure like the following when pushing V2 OPA policies:
 ```
 .
-+-- checks
++-- opa
+|   +-- policy1
+|       +-- policy.rego
+|   +-- policy2
+|       +-- policy.rego
+```
+
+* Note that it is possible to mix older V1 and these V2 policies within a single `opa` directory. The key differentiation is that V2 policies only have a `policy.rego` file.
+
+### Example
+To upload a`replicas` V2 OPA policy that requires Replicas to be specified for Kubernetes Deploymentss, create the file `./opa/replicas/policy.rego`
+(note that the filename _must_ be named `policy.rego`):
+
+```rego
+package fairwinds
+
+replicasRequired[actionItem] {
+  input.kind == "Deployment"
+  input.spec.replicas == 0
+  actionItem := {
+    "title": concat(" ", [input.kind, "does not have replicas set"]),
+    "description": "All workloads at acme-co must explicitly set the number of replicas. [Read more](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment)",
+    "remediation": "Please set `spec.replicas`",
+    "category": "Reliability",
+    "severity": 0.5
+  }
+}
+```
+
+* Note that the `replicasRequired` rule of the OPA policy first checks that `input.kind` is `Deployment`, which ensures this OPA policy only applies to Kubernetes Deployments. This is a difference between these V2 Insights OPA policies, compared to V1 policies.
+
+Next use the Insights CLI to push this OPA policy to Insights:
+
+```bash
+FAIRWINDS_TOKEN=YOUR_TOKEN insights-cli push opa --organization YOUR_ORG_NAME
+```
+
+* This pushes OPA policies from the current directory, expecting it to contain the `opa` sub-directory.
+* Typically the `FAIRWINDS_TOKEN` environment variable is set elsewhere and is not included each time the CLI is run.
+* The Insights organization can also be specified in a configuration file, described in the [general Insights CLI documentation](/configure/cli/cli).
+* Use the `--push-directory` option to specify an alternative base directory.
+* It is also possible to override the name of the `opa` sub-directory - see `insights-cli push opa --help` for details.
+
+#### Verifying Success
+To see a list of OPA policies in your Insights organization, you can run:
+
+```bash
+FAIRWINDS_TOKEN=YOUR_TOKEN insights-cli list opa --organization YOUR_ORG_NAME
+```
+
+If the [OPA report](/configure/policy/policy) is enabled, you can trigger it to run immediately, then verify new action items show up in the Insights UI.
+
+```bash
+kubectl -n insights-agent create job rule-test --from cronjob/opa
+```
+
+### Deleting From Insights
+By default, the Insights CLI will not _delete_ any OPA policies from Insights - it will
+only add or update them.
+This means there might be some OPA policies running in Insights that are not
+tracked in your IaC repository.
+
+You can add the `--delete` flag to the `push opa` command, which
+will delete any OPA policies from Insights that **do not exist** in your IaC repository. Adding the `--dry-run` flag will explain which resources would be deleted without making changes to Insights.
+
+## Pushing V1 Legacy OPA Policies To Insights
+The Insights CLI push commands expect a directory structure like the following when pushing V1 legacy OPA policies:
+```
+.
++-- opa
 |   +-- policy1
 |       +-- policy.rego
 |       +-- instance1.yaml
@@ -17,16 +87,14 @@ The sync functionality expects a directory structure like the following:
 |       +-- instance1.yaml
 ```
 
-Running `insights policy sync` from the root directory will upload any new/changed policies
-to the Insights API, and start applying them to each of your clusters.
+Each policy lives in its own directory, alongside the "policy instance" files that specify to which Kubernetes Kinds they should be applied.
 
-#### Example
+* Note that it is possible to mix these V1 and the newer V2 policies within a single `opa` directory. The key differentiation is that V2 policies only have a `policy.rego` file.
 
-The Insights CLI expects each policy to live in its own directory, alongside
-the rules that dictate where the rule should be applied.
-
-To upload our `replicasRequired` check, we start by creating `./replicas/policy.rego`
+### Example
+To upload a`replicas` V1 OPA policy that requires Replicas to be specified for Kubernetes Deploymentss, create the file `./opa/replicas/policy.rego`
 (note that the filename _must_ be named `policy.rego`):
+
 ```rego
 package fairwinds
 
@@ -42,8 +110,8 @@ replicasRequired[actionItem] {
 }
 ```
 
-Next, we'll create `./replicas/deployments.yaml` to tell Insights that this policy
-should be applied to all Deployments:
+Next, create the `./opa/replicas/deployments.yaml` file to tell Insights that this policy
+will be applied to all Kubernetes Deployments:
 ```yaml
 targets:
 - apiGroups: ["apps"]
@@ -51,11 +119,105 @@ targets:
 ```
 
 Finally, we can upload our policies using the CLI:
+
 ```bash
-FAIRWINDS_TOKEN=YOUR_TOKEN insights policy sync --organization your-org-name -d .
+FAIRWINDS_TOKEN=YOUR_TOKEN insights-cli push opa --organization YOUR_ORG_NAME
 ```
 
-To see a full list of your organization's policies, you can run:
+* This pushes OPA policies from the current directory, expecting it to contain the `opa` sub-directory.
+* Typically the `FAIRWINDS_TOKEN` environment variable is set elsewhere and is not included each time the CLI is run.
+* The Insights organization can also be specified in a configuration file, described in the [general Insights CLI documentation](/configure/cli/cli).
+* Use the `--push-directory` option to specify an alternative base directory.
+* It is also possible to override the name of the `opa` sub-directory - see `insights-cli push opa --help` for details.
+
+### Verifying Success
+To see a list of OPA policies in your Insights organization, you can run:
+
 ```bash
-FAIRWINDS_TOKEN=YOUR_TOKEN insights policy list --organization your-org-name
+FAIRWINDS_TOKEN=YOUR_TOKEN insights-cli list opa --organization YOUR_ORG_NAME
 ```
+
+### Deleting From Insights
+By default, the Insights CLI will not _delete_ any OPA policies from Insights - it will
+only add or update them.
+This means there might be some OPA policies running in Insights that are not
+tracked in your IaC repository.
+
+You can add the `--delete` flag to the `push opa` command, which
+will delete any OPA policies from Insights that **do not exist** in your IaC repository. Adding the `--dry-run` flag will explain which OPA policies would be deleted without making changes to Insights.
+
+## Pushing OPA Policies Along With Automation Rules
+
+Both OPA policies and automation rules can be pushed to Insights using the single command `insights-cli push all`.
+
+* Note that the `--delete` flag is not available for the `push all` command, to avoid unexpected deletes of insights-cli managed configuration resources that are added in the future.
+
+For additional information about automation rules, see the [CLI automation rules documentation](configure/cli/automation-rules.md).
+
+## Validate and Debug OPA Policies
+The Insights CLI can validate Insights OPA policies, which is useful for local policy development or or in your CI/CD workflow. Validation includes
+
+* Verifying rego syntax - the query language used by OPA policies.
+* Some input validation for Insights-provided rego functions, such as `kubernetes()` and `insightsinfo()`.
+* Displaying optional rego `print` statements, to aide in debugging.
+* Showing policy output, and validating it contains a valid Insights action item.
+
+The `insights-cli validate opa` command requires an OPA policy file, and a Kubernetes manifest file that will be passed as input to the policy.
+
+```bash
+insights-cli validate opa --rego-file not-in-namespace/policy.rego --kube-object-file test-pod.yaml
+```
+
+Other command-line options are available to override metadata to ease testing policies, such as
+
+* The Kubernetes namespace that may b specified in the manifest file, to help test policies that vary behavior per namespace.
+* Information returned by Insights-provided rego functions like `insightsinfo()`.
+
+See `insights-cli validate opa --help` and the [OPA Policy docs](/configure/cli/opa) for details.
+
+### Debug Print Statements
+Rego `print()` statements will be included in the output of `insights-cli validate opa`, to help debug policy execution. For example, this incomplete policy prints two debug messages.
+
+```rego
+package fairwinds
+
+incompleteRule[actionItem] {
+  print("starting our rule")
+  input.kind == "Deployment"
+  print("made it past the kind detection, which is ", input.kind)
+  actionItem := {
+    # This is incomplete!
+  }
+}
+```
+
+## Batch Validation of OPA Policies for CI/CD
+
+The `--batch-dir` option instructs the `insights-cli validate opa` command to process all `.rego` files in the specified directory.
+
+* Each `.rego` file is required to have an accompanying `.yaml` file containing the Kubernetes manifest that will be passed as input to that policy.
+* Unlike the above single-policy form of the `validate opa` command, bulk OPA policy validation requires that all policies return a single Insights action item. This means that the accompanying Kubernetes manifest should cause the OPA policy to output its Insights action item.
+
+### Example
+
+The `insights-cli validate opa` command expects the following directory structure when using the `--batch-directory` option.
+```
+.
++-- file.rego
++-- file.yaml
++-- another-policy.rego
++-- another-policy.yaml
+```
+
+* The base filename (minus the extension) is arbitrary.
+
+Next use the Insights CLI to validate all OPA policies
+
+```bash
+FAIRWINDS_TOKEN=YOUR_TOKEN insights-cli --organization YOUR_ORG_NAME validate opa --batch-directory .
+```
+
+* The `--batch-directory` option is required, to instruct `validate opa` to run in batch mode.
+* All policies must generate a single Insights action item as output, to be considered valid.
+* Typically the `FAIRWINDS_TOKEN` environment variable is set elsewhere and is not included each time the CLI is run.
+* The Insights organization can also be specified in a configuration file, described in the [general Insights CLI documentation](/configure/cli/cli).

--- a/docs/configure/cli/opa.md
+++ b/docs/configure/cli/opa.md
@@ -197,7 +197,7 @@ incompleteRule[actionItem] {
 The `--batch-dir` option instructs the `insights-cli validate opa` command to process all `.rego` files in the specified directory.
 
 * Each `.rego` file is required to have an accompanying `.yaml` file containing the Kubernetes manifest that will be passed as input to that policy.
-* Unlike the above single-policy form of the `validate opa` command, bulk OPA policy validation requires that all policies return a single Insights action item. This means that the accompanying Kubernetes manifest should cause the OPA policy to output its Insights action item.
+* The accompanying Kubernetes manifest should cause the OPA policy to output its Insights action item.
 
 ### Batch OPA Policy Validation Example
 

--- a/docs/configure/cli/opa.md
+++ b/docs/configure/cli/opa.md
@@ -159,7 +159,7 @@ For additional information about automation rules, see the [CLI automation rules
 The Insights CLI can validate Insights OPA policies, which is useful for local policy development or or in your CI/CD workflow. Validation includes
 
 * Verifying rego syntax - the query language used by OPA policies.
-* Some input validation for Insights-provided rego functions, such as `kubernetes()` and `insightsinfo()`.
+* Verifying Insights-provided functions have the correct number of parameters, such as `kubernetes()` and`insightsinfo()`. 
 * Displaying optional rego `print` statements, to aide in debugging.
 * Showing policy output, and validating it contains a valid Insights action item.
 
@@ -175,6 +175,11 @@ Other command-line options are available to override metadata to ease testing po
 * Information returned by Insights-provided rego functions like `insightsinfo()`.
 
 See `insights-cli validate opa --help` and the [OPA Policy docs](/configure/cli/opa) for details.
+
+### Insights-provided Rego Functions
+
+* The `kubernetes` function does not currently return data. In the future we hope to facilitate reading static Kubernetes manifest files which this function can query, in place of an OPA policy running in a live cluster.
+* The `insightsinfo` function will return static data, such as the cluster name and Insights context (Admission, Agent, CI/CD). THese are also configurable via command-line flags.
 
 ### Debug Print Statements
 Rego `print()` statements will be included in the output of `insights-cli validate opa`, to help debug policy execution. For example, this incomplete policy prints two debug messages.

--- a/docs/configure/cli/opa.md
+++ b/docs/configure/cli/opa.md
@@ -3,7 +3,8 @@ You can use the Insights Command-line Interface (CLI) To manage OPA policies, an
 Be sure to first read the [general CLI documentation](/configure/cli/cli) which covers instllation and prerequisites.
 
 ## V1 and V2 Insights OPA Policies
-Version 2 of the [Insights Agent](/configuration/agent/install-hub) supports a new `V2` version of Insights OPA policies which no longer uses an accompanying yaml file to define the Kubernetes Kinds that the policy will process. We recommend use of V2 policies moving forward. See the [[OPA report documentation](/configure/policy/policy) for more information about how V1 and V2 OPA policies differ.
+Version 2 of the [Insights Agent](/configure/agent/install-hub) supports a new `V2` method of specifying an OPA policy without an accompanying instance YAML file. This moves logic for varying policy execution by cluster, Insights context, or other parameters, directly into the policy rego.
+See the [[OPA report documentation](/configure/policy/policy) for more information about how V1 and V2 OPA policies differ.
 
 ## Pushing V2 OPA Policies to Insights
 The Insights CLI push commands expect a directory structure like the following when pushing V2 OPA policies:
@@ -18,7 +19,7 @@ The Insights CLI push commands expect a directory structure like the following w
 
 * Note that it is possible to mix older V1 and these V2 policies within a single `opa` directory. The key differentiation is that V2 policies only have a `policy.rego` file.
 
-### Example
+### Pushing V2 Policies Example
 To upload a`replicas` V2 OPA policy that requires Replicas to be specified for Kubernetes Deploymentss, create the file `./opa/replicas/policy.rego`
 (note that the filename _must_ be named `policy.rego`):
 
@@ -65,7 +66,7 @@ If the [OPA report](/configure/policy/policy) is enabled, you can trigger it to 
 kubectl -n insights-agent create job rule-test --from cronjob/opa
 ```
 
-### Deleting From Insights
+### Deleting OPA Policies From Insights
 By default, the Insights CLI will not _delete_ any OPA policies from Insights - it will
 only add or update them.
 This means there might be some OPA policies running in Insights that are not
@@ -91,7 +92,7 @@ Each policy lives in its own directory, alongside the "policy instance" files th
 
 * Note that it is possible to mix these V1 and the newer V2 policies within a single `opa` directory. The key differentiation is that V2 policies only have a `policy.rego` file.
 
-### Example
+### Pushing V1 Policies Example
 To upload a`replicas` V1 OPA policy that requires Replicas to be specified for Kubernetes Deploymentss, create the file `./opa/replicas/policy.rego`
 (note that the filename _must_ be named `policy.rego`):
 
@@ -137,7 +138,7 @@ To see a list of OPA policies in your Insights organization, you can run:
 FAIRWINDS_TOKEN=YOUR_TOKEN insights-cli list opa --organization YOUR_ORG_NAME
 ```
 
-### Deleting From Insights
+### Deleting OPA Policies From Insights
 By default, the Insights CLI will not _delete_ any OPA policies from Insights - it will
 only add or update them.
 This means there might be some OPA policies running in Insights that are not
@@ -152,7 +153,7 @@ Both OPA policies and automation rules can be pushed to Insights using the singl
 
 * Note that the `--delete` flag is not available for the `push all` command, to avoid unexpected deletes of insights-cli managed configuration resources that are added in the future.
 
-For additional information about automation rules, see the [CLI automation rules documentation](configure/cli/automation-rules.md).
+For additional information about automation rules, see the [CLI automation rules documentation](/configure/cli/automation-rules.md).
 
 ## Validate and Debug OPA Policies
 The Insights CLI can validate Insights OPA policies, which is useful for local policy development or or in your CI/CD workflow. Validation includes
@@ -198,7 +199,7 @@ The `--batch-dir` option instructs the `insights-cli validate opa` command to pr
 * Each `.rego` file is required to have an accompanying `.yaml` file containing the Kubernetes manifest that will be passed as input to that policy.
 * Unlike the above single-policy form of the `validate opa` command, bulk OPA policy validation requires that all policies return a single Insights action item. This means that the accompanying Kubernetes manifest should cause the OPA policy to output its Insights action item.
 
-### Example
+### Batch OPA Policy Validation Example
 
 The `insights-cli validate opa` command expects the following directory structure when using the `--batch-directory` option.
 ```

--- a/docs/configure/policy/policy.md
+++ b/docs/configure/policy/policy.md
@@ -118,6 +118,7 @@ The Insights OPA plugin executes OPA policies for these Kubernetes resources by 
 * Deployments
 * DaemonSets
 * StatefulSets
+* Pods
 * Jobs
 * CronJobs
 

--- a/docs/configure/policy/policy.md
+++ b/docs/configure/policy/policy.md
@@ -103,19 +103,89 @@ kubectl create job my-opa-test --from=cronjob/opa -n insights-agent
 
 Watch the pod logs for the resulting Job to spot any potential errors in your OPA policy.
 
-The Insights CLI also facilitates offline testing of OPA policies, see the [CLI OPA policy documentation](/configure/cli/opa).
+The Insights CLI also facilitates offline testing of OPA policies, see the [CLI OPA policy validation documentation](/configure/cli/opa#validate-and-debug-opa-policies).
+
+## V1 and V2 Insights OPA Policies
+Version 2 of the [Insights Agent](/configure/agent/install-hub) supports a new `V2` method of specifying an OPA policy without an accompanying instance YAML file. This moves logic for varying policy execution by cluster, Insights context, or other parameters, directly into the policy rego. We recommend use of V2 policies moving forward, but continue to support V1 OPA policies.
+
+Here are some frequently asked questions about the V1 and V2 differences:
+
+#### Q: Without an instance YAML, how do V2 policies define the Kubernetes Kinds to which the OPA policy applies?
+The rego should check the Kubernetes kind, by inspecting `input.kind`.  
+
+The Insights OPA plugin executes OPA policies for these Kubernetes resources by default:
+
+* Deployments
+* DaemonSets
+* StatefulSets
+* Jobs
+* CronJobs
+
+If you'd like to add additional resources, you can use the `opa.targetResources`
+[insights-agent Helm chart value](https://github.com/FairwindsOps/charts/blob/master/stable/insights-agent/values.yaml):
+
+```yaml
+opa:
+  enabled: true
+  targetResources:
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingress
+```
+
+By default the OPA plugin inharits the same Kubernetes APIGroups and Resources definedin default rules for [the admission controller](/configure/admission/configuration), if enabled.
+
+#### Q: How do I vary OPA policy execution By cluster or Insights context?
+Insights provides a new `insightsinfo()` rego function, which accepts the following parameters:
+
+* `cluster` - returns the Kubernetes cluster where the OPA policy is executing.
+* `context` - Returns the Insights context in which the policy is executing
+	* Admission for the admission controller
+	* Agent for the Insights agent (OPA plugin)
+	* `CI/CD` for the Insights CI integration.
 
 ## Tips and Tricks
 
-### Reusing Rego Policies
-You can reuse the same Rego policy, setting different ActionItem attributes in different cases.
+### Varying Action Item Attributes
+You can reuse the same Rego policy, setting different ActionItem attributes for different cases.
 For instance, say we wanted to apply our `replicas` policy above to both `Deployments` and `StatefulSets`,
 but wanted a higher severity for `Deployments`.
 
-#### V2 OPA Policies
+#### V2 OPA Policy Variable Attributes Example
+This policy varies the severity depending on the `input.kind`:
 
-#### V1 OPA Policies
-First, we'd stop specifying `severity` inside our OPA, so that it can be set by the instance:
+```rego
+package fairwinds
+
+replicasRequired[actionItem] {
+  # List the Kubernetes Kinds to which this policy should apply.
+  kinds := {"Deployment", "StatefulSet"}
+  # List severities for each of the above Kinds. Kind.
+  severityByKind := {
+    "StatefulSet": 0.4,
+    "Deployment": 0.9,
+  }
+  # Iterate Kinds{} and only continue if input.kind is one of them.
+  kind := kinds[val]
+  input.kind == kind
+  input.spec.replicas == 0
+  # Set the severity based on the Kind.
+  dynamicSeverity := severityByKind[input.kind]
+  actionItem := {
+    "title": concat(" ", [input.kind, "does not have replicas set"]),
+    "description": "All workloads at acme-co must explicitly set the number of replicas. [Read more](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment)",
+    "remediation": "Please set `spec.replicas`",
+    "category": "Reliability",
+    "severity": dynamicSeverity,
+  }
+}
+```
+
+#### V1 OPA Policy Variable Attributes Example
+We recommend using V2 Insights OPA policies (above). These instructions remain here for backward compatibility.
+
+First, we'd stop specifying `severity` directly inside the action item returned by the OPA policy, so that it can be set in the instance file:
 **replicas.rego**
 ```rego
 package fairwinds
@@ -150,9 +220,31 @@ targets:
   kinds: ["StatefulSet"]
 ```
 
-#### Run Types
+### Restricting OPA Policies By Insights Context
+You can restrict an OPA policy to only run in certain Insights contexts - the Insights agent, admission controller, or CI/CD. By default an OPA policy will run in all available contexts. Note that the names of contexts differ slightly for V1 vs. V2 Insights OPA policies.
 
-In addition to targeting specific types of resources you can also specify your instance to only run in certain contexts. By default an instance will run in all available contexts, but if you specify a `runEnvironments` section of your YAML then it will only run in the environments selected.
+#### V2 OPA Policy Context Example
+Insights provides an `insightsinfo()` rego function which can return the Insights context:
+
+* Admission
+* Agent
+* CI/CD
+
+In rego, you can require the value of `insightsinfo("context")` using code like this:
+
+```rego
+  context := insightsinfo("context")
+  # List the Insights contexts in which this policy should apply.
+  validContexts := {"Admission", "Agent"}
+  # Only continue if the policy is executing in one of validContexts{}
+  validContext := validContexts[val]
+  context == validContext
+```
+
+#### V1 OPA Policy Context Example
+We recommend using V2 Insights OPA policies (above). These instructions remain here for backward compatibility.
+
+Specifying a `runEnvironments` section of your Instance YAML will limit that OPA policy to the contexts selected:
 
 ```yaml
 runEnvironments:
@@ -164,9 +256,26 @@ targets:
   kinds: ["StatefulSet"]
 ```
 
-#### Clusters
+* Note that these context values are different from those use in a V2 Insights OPA policy.
 
-If you want to restrict a policy to only running on a specific cluster you can specify which clusters to run in. By default an instance will run in all available clusters, but if you specify a `clusters` section of your YAML then it will only run in the clusters selected.
+### Varying Execution by Kubernetes Clusters
+You can restrict an OPA policy to run in specific Kubernetes clusters. By default an OPA policy  will run in all available clusters.
+
+#### V2 OPA Policy Limiting Clusters Example
+
+```rego
+  # List the Kubernetes clusters to which this policy should apply.
+  validClusters := {"cluster1", "cluster2"}
+  # Only continue if the policy is executing in one of validClusters{}
+  cluster := insightsinfo("cluster")
+  validCluster := validClusters[val]
+  cluster == validCluster
+```
+
+#### V1 OPA Policy Limiting Clusters Example
+We recommend using V2 Insights OPA policies (above). These instructions remain here for backward compatibility.
+
+Specifying a `clusters` section in the instance YAML will only execute that OPA policy in those clusters.
 
 ```yaml
 clusters:
@@ -176,9 +285,47 @@ targets:
   kinds: ["StatefulSet"]
 ```
 
-#### Parameters
-We can also pass parameters to our instances. Say, for instance, that we wanted all Deployments to have at least 3 replicas,
-but StatefulSets were OK with a single replica. Then we could write:
+### Variable Parameters
+If we want all Deployments to have at least 3 replicas,
+but StatefulSets were OK with a single replica, we can vary this value based on the Kubernetes Kind.
+
+```rego
+
+```
+
+#### V2 OPA Policy Variable Parameters Example
+This rego uses a variable to define the minimum number of replicas for each Kubernetes Kind.
+
+```rego
+package fairwinds
+
+replicasRequired[actionItem] {
+  # List the Kubernetes Kinds to which this policy should apply.
+  kinds := {"Deployment", "StatefulSet"}
+  # List  the minimum required replicas for each of the above Kinds.
+  minReplicasByKind := {
+    "StatefulSet": 1,
+    "Deployment": 3,
+  }
+  # Iterate Kinds{} and only continue if input.kind is one of them.
+  kind := kinds[val]
+  input.kind == kind
+  minReplicas := minReplicasByKind[input.kind]
+  input.spec.replicas < minReplicas
+  actionItem := {
+    "title": sprintf("%s doesnot have a minimum of %d replicas", [input.kind, minReplicas]),
+    "description": "All workloads at acme-co must explicitly set the number of replicas. [Read more](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment)",
+    "remediation": "Please set `spec.replicas`",
+    "category": "Reliability",
+    "severity": 0.2,
+  }
+}
+```
+
+#### V1 OPA Policy Variable Parameters Example
+We recommend using V2 Insights OPA policies (above). These instructions remain here for backward compatibility.
+
+This rego uses a parameter defined separately, in each instance YAML file.
 
 ```rego
 package fairwinds
@@ -186,10 +333,11 @@ package fairwinds
 replicasRequired[actionItem] {
   input.spec.replicas < input.parameters.minReplicas
   actionItem := {
-    "title": concat(" ", [input.kind, "does not have enough replicas set"]),
+    "title": sprintf("%s does not have enough replicas set", [input.kind]),
     "description": "All workloads at acme-co must explicitly set the number of replicas. [Read more](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment)",
     "remediation": "Please set `spec.replicas`",
     "category": "Reliability",
+    severity: 0.2,
   }
 }
 ```
@@ -213,8 +361,7 @@ targets:
 ```
 
 ### Using the Kubernetes API
-You can also cross-check resources with other Kubernetes objects. For example, we could use
-this check to ensure that all `Deployments` have an associated `HorizontalPodAutoscaler`:
+You can cross-check OPA policy input with Kubernetes objects from the cluster, at policy execution time. For example, this check ensures that all `Deployments` have an associated `HorizontalPodAutoscaler`:
 
 ```rego
 package fairwinds


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Update Insights Docs to reflect

* Referring to `custom checks` or `checks` as `OPA policies`
* Add general info and some FAQs about V1 vs. V2 policies (in the general policy doc).
* Update OPA Policy examples (in general policy docs) to include V2 examples that help differentiate V1 from V2, and note that V1 documentation is retained for backward compatibility but V2 policies are recommended.
* Update to reflect new Insights CLI command structure and flags
* Add new CLI OPA policy validation, and link to it from other places testing policies is mentioned.
* Adjustments to some wording, order of sub-sections, and naming headings and link-text to be more complete thoughts (`this doc` might become `the CLI OPA doc`).

### What changes did you make?


[Internal Ticket FWI-1726](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-1726)