### PR TITLE
Update configuration.md

### DIFF
--- a/docs/configure/ci/configuration.md
+++ b/docs/configure/ci/configuration.md
@@ -136,6 +136,7 @@ You can control which scan tools (known as 'reports') are run as part of an Insi
 * `reports.opa.enabled` - Boolean - set to `false` if you'd like to disable OPA
 * `reports.polaris.enabled` - Boolean - set to `false` if you'd like to disable Polaris
 * `reports.trivy.enabled` - Boolean - set to `false` if you'd like to disable Trivy
+* `reports.tfsec.enabled` - Boolean - set to `false` if you'd like to disable tfsec Terraform file scanning
 * `reports.trivy.skipManifests` - Boolean - set to `true` if you don't want to scan images discovered in YAML files and Helm charts
 
 ## Troubleshooting Insights CI


### PR DESCRIPTION
Unsure if tfsec scanning is defaulted to enabled or disabled, I guessed based on the line that all reports are default enabled

Added line 139. If tfsec is defaulted to disabled then we should delete the text on line 134 "By default, all reports are enabled."


This PR fixes #

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Added a line to include the tfsec report 

### What changes did you make?
Added line 139 to include tfsec report under "enable/disable reports" header. 

Unsure if tfsec scanning is defaulted to enabled or disabled, I guessed based on the line that all reports are default enabled



### What alternative solution should we consider, if any?
If tfsec is actually defaulted to disabled then we should delete the text on line 134 "By default, all reports are enabled."
