### PR TITLE
FWI-3280 - Vv/add docs for reports cfg api/fwi 3280

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 ## DO NOT EDIT - Managed by Terraform
-* @rbren @makoscafee @ddakoda @jpelletier1 @mhoss019 @ivanfetch-fw @tarynmartin @jdesouza @vitorvezani @mggude
+* @rbren @ddakoda @jpelletier1 @mhoss019 @ivanfetch-fw @tarynmartin @jdesouza @vitorvezani @mggude

--- a/docs/configure/ci/autoscan.md
+++ b/docs/configure/ci/autoscan.md
@@ -8,7 +8,44 @@ meta:
 *Documentation coming soon!*
 
 ## Using Auto-Scan to Scan Private Images
-Scanning private container images is not yet supported in Auto-Scan but is currently on-roadmap.
+You can now scan private container images by setting up docker registries information in Fairwinds Insights via API.
+These information will be used to authenticate/authorize against your docker registry and fetch private image container to be scanned.
+
+### Add docker registry
+```
+curl --location --request POST 'https://insights.fairwinds.com/v0/organizations/{orgName}/ci/docker-registries' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer {insightsToken}' \
+--data-raw '{"domain":"docker.io","username":"usernameOrEmail","password":"p4ssw0rd"}'
+```
+You can also use `token` instead of `username:password` to authorize against your docker registry. When token is used the `username` field should be `<token>` and the `token` must be provided using the `password` field, i.e:
+```
+{"domain":"docker.io","username":"<token>","password":"t0k3nV4lu3"}
+```
+
+The field `password` is safely encrypted before being persisted on Fairwinds Insights databases.
+
+### List docker registries
+```
+curl --location --request GET 'https://insights.fairwinds.com/v0/organizations/{orgName}/ci/docker-registries' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer {insightsToken}'
+```
+
+### Edit docker registry
+```
+curl --location --request PUT 'https://insights.fairwinds.com/v0/organizations/{orgName}/ci/docker-registries/{dockerRegistryID}' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer {insightsToken}' \
+--data-raw '{"domain":"docker.io","username":"usernameOrEmail","password":"p4ssw0rd"}'
+```
+
+### Delete docker registry
+```
+curl --location --request PUT 'https://insights.fairwinds.com/v0/organizations/{orgName}/ci/docker-registries/{dockerRegistryID}' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer {insightsToken}'
+```
 
 ## Re-Running an Auto-Scan
 You can manually re-run an Auto-Scan for specific repository branches. This may be useful if you'd like a refreshed result set, or if you'd like to verify any fixes or changes.

--- a/docs/configure/ci/autoscan.md
+++ b/docs/configure/ci/autoscan.md
@@ -20,10 +20,35 @@ To re-run an Auto-Scan:
 
 Re-running an Auto-Scan job usually takes a few minutes. Look for the 'Completed' status to see your latest results.
 
-## Customizing Auto-Scan Using Fairwinds-insights.yaml
-Unlike the Insights CI integration, Auto-Scan does not require users to create a `fairwinds-insights.yaml` configuration file at the base of their GitHub repository. This is because Auto-Scan will automatically crawl and discover YAML manifests, Helm charts, and docker images available for scanning.
+## Manifests auto-discovery
+Unlike Insights CI integration, Auto-Scan does not require users to create a `fairwinds-insights.yaml` configuration file at the base of their GitHub repository. This is because Auto-Scan will automatically crawl and discover YAML manifests, Helm charts, and docker images available for scanning.
 
-However, sometimes users may want to customize Auto-Scan behaviors for a specific repo. To do this, you can create a `fairwinds-insights.yaml` file at the root of your git repo and customize things like:
+### Reports Configuration
+When using auto-discovery, all reports are `enabled` by default, if you want to further customize. It is possible to manually configure it via API using CURL:
+```
+curl --location --request POST 'https://insights.fairwinds.com/v0/organizations/{orgName}/ci/repositories/{repositoryID}/reports-config' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer {adminToken}' \
+--data-raw '{
+  "autoScan": {
+    "polaris": { "enabledOnAutoDiscovery": false },
+    "tfsec": { "enabledOnAutoDiscovery": false }
+  }
+}'
+```
+This configuration disables `polaris` and `tfsec` when using auto-discovery
+
+Possible report types are: `polaris`, `opa`, `pluto`, `trivy`, `tfsec`
+
+To fetch your current configuration using CURL:
+```
+curl --location --request GET 'https://insights.fairwinds.com/v0/organizations/{orgName}/ci/repositories/{repositoryID}/reports-config' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer {adminToken}'
+```
+
+## Customizing Auto-Scan Using Fairwinds-insights.yaml
+Sometimes users may want to customize Auto-Scan behaviors for a specific repo. To do this, you can create a `fairwinds-insights.yaml` file at the root of your git repo and customize things like:
 - [Configuring specific exemptions](/configure/ci/configuration#managing-exemptions)
 - [Resolving Helm chart errors due to missing values](/configure/ci/autoscan#helm-chart-with-invalid-or-missing-values-file)
 - [Scanning additional container images not present in your manifests](/configure/ci/configuration#scanning-container-images)

--- a/docs/configure/ci/autoscan.md
+++ b/docs/configure/ci/autoscan.md
@@ -84,6 +84,20 @@ curl --location --request GET 'https://insights.fairwinds.com/v0/organizations/{
 --header 'Authorization: Bearer {adminToken}'
 ```
 
+### CI plugin version override
+When not explicitly set, auto-scan will run on a sensible default version set by Fairwinds. However, you may want to configure the CI plugin version to a different one on your repository.
+
+To customize this, you can manually configure via API using CURL:
+```
+curl --location --request PUT 'https://insights.fairwinds.com/v0/organizations/{orgName}/ci/repositories/{repositoryID}' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer {adminToken}' \
+--data-raw '{
+  "CIPluginVersion": "X.Y.Z"
+}'
+```
+Make sure the provide version is [SemVer](https://semver.org/) compliant
+
 ## Customizing Auto-Scan Using Fairwinds-insights.yaml
 Sometimes users may want to customize Auto-Scan behaviors for a specific repo. To do this, you can create a `fairwinds-insights.yaml` file at the root of your git repo and customize things like:
 - [Configuring specific exemptions](/configure/ci/configuration#managing-exemptions)

--- a/docs/configure/ci/autoscan.md
+++ b/docs/configure/ci/autoscan.md
@@ -9,7 +9,7 @@ meta:
 
 ## Using Auto-Scan to Scan Private Images
 You can now scan private container images by setting up docker registries information in Fairwinds Insights via API.
-These information will be used to authenticate/authorize against your docker registry and fetch private image container to be scanned.
+This information will be used to authenticate/authorize against your docker registry and fetch the private image container to be scanned.
 
 ### Add docker registry
 ```

--- a/docs/configure/ci/autoscan.md
+++ b/docs/configure/ci/autoscan.md
@@ -61,7 +61,7 @@ Re-running an Auto-Scan job usually takes a few minutes. Look for the 'Completed
 Unlike Insights CI integration, Auto-Scan does not require users to create a `fairwinds-insights.yaml` configuration file at the base of their GitHub repository. This is because Auto-Scan will automatically crawl and discover YAML manifests, Helm charts, and docker images available for scanning.
 
 ### Reports Configuration
-When using auto-discovery, all reports are `enabled` by default, if you want to further customize. It is possible to manually configure it via API using CURL:
+When using auto-discovery, all reports are enabled by default. To customize this, you can manually configure via API using CURL:
 ```
 curl --location --request POST 'https://insights.fairwinds.com/v0/organizations/{orgName}/ci/repositories/{repositoryID}/reports-config' \
 --header 'Content-Type: application/json' \

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,10 @@ sidebarDepth: 1
 ---
 # Release Notes
 
+## 10.11.0
+### Bug Fixes and Improvements
+* Updated Insights welcome Email
+
 ## 10.10.0
 ### Bug Fixes and Improvements
 * Insights Agent 2.9 is now recommended in the `Install Hub`

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,10 @@ sidebarDepth: 1
 ---
 # Release Notes
 
+## 10.10.0
+### Bug Fixes and Improvements
+* Insights Agent 2.9 is now recommended in the `Install Hub`
+
 ## 10.9.0
 ### Bug Fixes and Improvements
 * Status indicator for Auto-Scan repositories takes user to scan logs

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,10 @@ sidebarDepth: 1
 ---
 # Release Notes
 
+## 10.12.0
+### Bug Fixes and Improvements
+* Hide settings and add repository buttons from non-owners
+
 ## 10.11.0
 ### Bug Fixes and Improvements
 * Updated Insights welcome Email

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,10 @@ sidebarDepth: 1
 ---
 # Release Notes
 
+## 11.0.0
+### Bug Fixes and Improvements
+* Fixed `Cost Over Time` chart in `Costs` page
+
 ## 10.12.0
 ### Bug Fixes and Improvements
 * Hide settings and add repository buttons from non-owners


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Adds documentation for: 
- Docker registry API - Scan private images
- Auto-scan Reports config.

### What changes did you make?

### What alternative solution should we consider, if any?

