### PR TITLE
Reflect FWI-3942: ability to manage admission-controller settings via  the policy configurator settings.yaml file

### DIFF
--- a/docs/configure/admission/configuration.md
+++ b/docs/configure/admission/configuration.md
@@ -40,4 +40,4 @@ insights-admission:
 
 # Passive Mode and Report Types
 
-The [admission controller install hub](/configure/admission/installhub-and-policies) and [Insights CLI policy configuration](/configure/cli/settings) documentation describes methods for [setting admission controller passive mode](/installation/admission/setup/#installation), and which report types will be used with admission controller.
+The [admission controller install hub](/configure/admission/installhub-and-policies) and [Insights CLI policy configuration](/configure/cli/settings) documentation describes methods for [setting admission controller passive mode](/installation/admission/setup), and which report types will be used with admission controller.

--- a/docs/configure/admission/configuration.md
+++ b/docs/configure/admission/configuration.md
@@ -37,3 +37,7 @@ insights-admission:
       - customResource
       scope: Namespaced
 ```
+
+# Passive Mode and Report Types
+
+The [admission controller install hub](/configure/admission/installhub-and-policies) and [Insights CLI policy configuration](/configure/cli/settings) documentation describes methods for [setting admission controller passive mode](/installation/admission/setup/#installation), and which report types will be used with admission controller.

--- a/docs/configure/cli/settings.md
+++ b/docs/configure/cli/settings.md
@@ -21,8 +21,21 @@ checks:
         block: <true/false>
       admission:
         block: <true/false>
+AdmissionSettings: # Optionally specify per-org or per-cluster admission controller settings
+  passiveMode: <true/false> # Sets passive mode organization-wide
+  opaEnabled: <true/false> # Enable OPA policies with admission, organization-wide
+  plutoEnabled: <true/false> # Enable pluto with admission, organization-wide
+  polarisEnabled: <true/false> # Enable polaris with admission, organization-wide
+  Clusters: # Specify settings per-cluster
+    - ClusterName: dev
+      passiveMode: <true/false>
+      opaEnabled: <true/false>
+      plutoEnabled: <true/false>
+      polarisEnabled: <true/false>
 ```
-For OPA policies, the `$reportType` is `opa` and the `$eventType` is the Policy name.
+
+* For OPA policies under the `checks` section, the `$reportType` is `opa` and the `$eventType` is the Policy name.
+* The `AdmissionSettings` section requires the `passiveMode` and `polarisEnabled` options to be specified.
 
 Once the file has been created, use the following command to push the Policies Configuration:
 ```
@@ -50,7 +63,7 @@ Next use the Insights CLI to push these configurations to Insights:
 insights-cli push settings
 ```
 
->The customizations in `settings.yaml` will override any previous customizations made in Insights. For example, if the above yaml was later pushed without `livenessProbeMissing`, that Policy would revert to the default values.
+>The customizations in the `checks` portion of `settings.yaml` will override any previous customizations made in Insights. For example, if the above yaml was later pushed without `livenessProbeMissing`, that Policy would revert to the default values.
 
 ## Verifying the Configuration of Policies
 1. In Insights, go to the `Policy` page
@@ -58,7 +71,7 @@ insights-cli push settings
 
 This should show you the Policies that have been modified using the `settings.yaml` file.
 
-## Pushing Policies Configuration Along With Other Configurations
-Configuration of Policies can be pushed to Insights along with other Insights configurations using the single command `insights-cli push all`. For additional information see
+## Pushing Policies Configuration Along With Other Configuration Types
+Configuration of Policies can be pushed to Insights along with other types of Insights configuration using the single command `insights-cli push all`. For additional information see
 * [Automation Rules with CLI](/configure/cli/automation-rules)
 * [OPA policies With CLI](/configure/cli/opa)


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Document the new ability to manage admission controller settings (passive mode and which reports are enabled) via the settings.yaml file. This updates the CLI documentation, and adds additional references to help make readers aware that this is possible.

This documentation updates goes with this [PR to implement the functionality in the backend](https://github.com/FairwindsOps/Insights/pull/3860).
