### PR TITLE
Fix JSON array syntax

### DIFF
--- a/docs/first-steps/policy-enforcement.md
+++ b/docs/first-steps/policy-enforcement.md
@@ -293,7 +293,7 @@ Automation Rule: `ignore-via-annotation`
 Context: Admission Controller
 
 ```javascript
-//Bypass Admission Controller if an annotation such as 'insights.fairwinds.com/ignore: runAsRootAllowed' exists
+//Bypass Admission Controller if an annotation like this exists: insights.fairwinds.com/ignore: "[\"runAsRootAllowed\"]"
 policyException =
   ActionItem.ResourceAnnotations["insights.fairwinds.com/ignore"];
 


### PR DESCRIPTION
fix example syntax to use JSON in annotation:
insights.fairwinds.com/ignore: "[\"runAsRootAllowed\"]"

This PR fixes #

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

