### PR TITLE
Change falco chart options to reflect latest

### DIFF
--- a/docs/technical-details/reports/falco.md
+++ b/docs/technical-details/reports/falco.md
@@ -40,7 +40,7 @@ falcosidekick:
       address: "http://falco-agent.insights-agent:3031/data"
 ```
 
-*Please always consult the upstream chart for the latest configuration options and values.
+*Please always consult the upstream chart for the latest configuration options and values. The latest version as of this writing is `3.1.5`.
 
 ### Insights
 To enable Falco in the insights-agent, add this to your values.yaml:

--- a/docs/technical-details/reports/falco.md
+++ b/docs/technical-details/reports/falco.md
@@ -19,7 +19,7 @@ Some are less severe, like an attempt to run interactive commands by a system
 ## Setup
 ### Install Falco
 First, you'll need to install Falco in your cluster. We recommend using these values when installing
-via the [Helm chart](https://github.com/falcosecurity/charts/tree/master/falco):
+via the [Helm chart](https://github.com/falcosecurity/charts/tree/master/falco)*:
 ```yaml
 resources:
   requests:
@@ -29,8 +29,8 @@ resources:
     cpu: 200m
     memory: 512Mi
 falco:
-  jsonOutput: true
-ebpf:
+  json_output: true
+driver:
   enabled: false # You can enable this on newer nodes that support eBPF
 falcosidekick:
   enabled: true
@@ -39,6 +39,8 @@ falcosidekick:
     webhook:
       address: "http://falco-agent.insights-agent:3031/data"
 ```
+
+*Please always consult the upstream chart for the latest configuration options and values.
 
 ### Insights
 To enable Falco in the insights-agent, add this to your values.yaml:


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Update the Falco chart value recommendations to match changes that have been made to the upstream chart since this was written.

### What changes did you make?
Change two keys that differ (the `ebpf` key and the `json_output` key) and encourage users to refer to the upstream chart in case our documentation is not reflective of the most recent configuration options. 


### What alternative solution should we consider, if any?
None. 
