### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/features/policies.md
+++ b/docs/features/policies.md
@@ -154,7 +154,7 @@ replicasRequired[actionItem] {
   input.kind == "Deployment"
   input.spec.replicas == 0
   actionItem := {
-    "title": Deployment does not have replicas set",
+    "title": "Deployment does not have replicas set",
     "description": "All workloads at acme-co must explicitly set the number of replicas",
     "remediation": "Please set `spec.replicas`",
     "category": "Reliability",
@@ -186,7 +186,7 @@ replicasRequired[actionItem] {
   # Set the severity based on the Kind.
   dynamicSeverity := severityByKind[input.kind]
   actionItem := {
-    "title": "Deployment oes not have replicas set",
+    "title": "Deployment does not have replicas set",
     "description": "All workloads at acme-co must explicitly set the number of replicas",
     "remediation": "Please set `spec.replicas`",
     "category": "Reliability",


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Fix typos in documentation for rego functions

### What changes did you make?
Just some quotation marks and a small typo.
 
### What alternative solution should we consider, if any?

