### PR TITLE
make ingress plural in the adding resources to opa example

### DIFF
--- a/docs/features/policies.md
+++ b/docs/features/policies.md
@@ -325,7 +325,7 @@ opa:
   - apiGroups:
     - networking.k8s.io
     resources:
-    - ingress
+    - ingresses
 ```
 
 By default the OPA plugin inherits the same Kubernetes APIGroups and Resources defined in the default rules for [the Admission Controller](/features/admission-controller).


### PR DESCRIPTION

This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To fix the example configuration snippet for adding a resource to OPA

### What changes did you make?
Made the singular ingress plural. 

### What alternative solution should we consider, if any?

