### PR TITLE
Update PostgreSQL password field in installation guide

### DIFF
--- a/docs/technical-details/self-hosted/installation.md
+++ b/docs/technical-details/self-hosted/installation.md
@@ -22,7 +22,7 @@ helm install fairwinds-insights fairwinds-stable/fairwinds-insights \
   --set options.autogenerateKeys=true \
   --set options.allowHTTPCookies=true \
   --set postgresql.sslMode=disable \
-  --set postgresql.password=THISISASECRET \
+  --set postgresql.auth.password=THISISASECRET \
   --set installationCode="$FAIRWINDS_PROVIDED_CODE"
 ```
 


### PR DESCRIPTION
This PR fixes #

`postgresql.password` is not used, use `postgresql.auth.password` instead

https://github.com/FairwindsOps/charts/blob/c593a958b5695218aa18d68d521e13e7118b115c/stable/fairwinds-insights/templates/secret.yml#L18

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

